### PR TITLE
Fixes error in parameters of prepared statements during rewrite

### DIFF
--- a/datasette_parquet/ducky.py
+++ b/datasette_parquet/ducky.py
@@ -83,7 +83,16 @@ class DuckDatabase(Database):
             raise Exception('non-threaded mode not supported')
 
         def in_thread():
-            return fn(self.conn)
+            try:
+                return fn(self.conn)
+            except duckdb.OperationalError as e:
+                raise sqlite3.OperationalError(str(e))
+            except duckdb.ProgrammingError as e:
+                raise sqlite3.ProgrammingError(str(e))
+            except duckdb.InternalError as e:
+                raise sqlite3.InternalError(str(e))
+            except duckdb.DataError as e:
+                raise sqlite3.DatabaseError(str(e))
 
         return await asyncio.get_event_loop().run_in_executor(
             self.ds.executor, in_thread
@@ -94,7 +103,16 @@ class DuckDatabase(Database):
             raise Exception('non-threaded mode not supported')
 
         def in_thread():
-            return fn(self.conn)
+            try:
+                return fn(self.conn)
+            except duckdb.OperationalError as e:
+                raise sqlite3.OperationalError(str(e))
+            except duckdb.ProgrammingError as e:
+                raise sqlite3.ProgrammingError(str(e))
+            except duckdb.InternalError as e:
+                raise sqlite3.InternalError(str(e))
+            except duckdb.DataError as e:
+                raise sqlite3.DatabaseError(str(e))
 
         # We lie, we'll always block.
         return await asyncio.get_event_loop().run_in_executor(

--- a/datasette_parquet/ducky.py
+++ b/datasette_parquet/ducky.py
@@ -1,5 +1,6 @@
 import asyncio
 import duckdb
+import sqlite3
 from .debounce import debounce
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler, LoggingEventHandler
@@ -118,4 +119,3 @@ class DuckDatabase(Database):
         return await asyncio.get_event_loop().run_in_executor(
             self.ds.executor, in_thread
         )
-

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     version=VERSION,
     packages=["datasette_parquet"],
     entry_points={"datasette": ["parquet = datasette_parquet"]},
-    install_requires=["datasette", "duckdb", "sqlglot", "watchdog"],
+    install_requires=["datasette", "duckdb", "sqlglot >= 21.2", "watchdog"],
     extras_require={"test": ["pytest", "pytest-asyncio", "pytest-watch"]},
     python_requires=">=3.7",
 )


### PR DESCRIPTION
Fixes #23

The dependencies for this package are unpinned. `sqlglot` upstream changed their rewriting to do more, so this package now needs to do a little less.

This commit removes some rewriting that was failing with recent package versions, and pins `sqlglot >= 21.2` in `setup.py`.

In doing so, it gets table display working again in Datasette.